### PR TITLE
Add environment variable for enhanced user agent

### DIFF
--- a/src/DOS/DOSNet.cpp
+++ b/src/DOS/DOSNet.cpp
@@ -370,8 +370,14 @@ void DOSHTTPRequest::Update()
 				break;
 			case SendHeaders:
 				{
+					char* agent = getenv("HTTP_USER_AGENT");
 					WriteLine("GET %s HTTP/1.0", path);
-					WriteLine("User-Agent: MicroWeb " __DATE__);
+					if (agent == NULL) {
+						WriteLine("User-Agent: MicroWeb " __DATE__);
+					}
+					else {
+						WriteLine("User-Agent: MicroWeb %s %s", __DATE__, agent);
+					}
 					WriteLine("Host: %s", hostname);
 					WriteLine("Connection: close");
 					WriteLine();


### PR DESCRIPTION
Proposed patch to resolve #11.

I thought offering the patch might help the discussion, since none was happening on the issue. I've not written any C++ in a long time, but this builds for me locally and seems to work as expected.

I provided more client details in `HTTP_USER_AGENT` and then hit http://whatsmyuseragent.org/ and they appeared. Old behavior is preserved if the env variable is unset.