### PR TITLE
Fix wrong file path in the download dialog

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -715,17 +715,23 @@ void App::ShowDownloadDialogPage()
 	parser.Write("<form action=\"download://\">");
 	parser.Write("<input name=\"path\" type=\"text\" width=\"75%\" value=\"");
 
-	char* currentDirectory = getcwd(NULL, 0);
-	//Non-root folders has no \ at the end - let's add it!
-	const size_t currentDirStrLen = strlen(currentDirectory);
-	if (currentDirectory[currentDirStrLen-1] != '\\')
+	char currentDirectory[PATH_MAX + 1];
+	if (getcwd(currentDirectory, (PATH_MAX + 1)) == NULL)
 	{
-		currentDirectory[currentDirStrLen] = '\\';
+		parser.Write("Can't get current path: ");
+		parser.Write(strerror(errno));
 	}
-	parser.Write(currentDirectory);
-	free(currentDirectory);
+	else
+	{
+		parser.Write(currentDirectory);
+		// Non-root folders has no \ at the end - let's add it!
+		if (currentDirectory[strlen(currentDirectory) - 1] != '\\')
+		{
+			parser.Write("\\");
+		}
+		parser.Write(filename);
+	}
 
-	parser.Write(filename);
 	parser.Write("\"/><br>");
 	parser.Write("<br>");
 	parser.Write("<input type=\"button\" value=\"Download\"/>");

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -714,10 +714,17 @@ void App::ShowDownloadDialogPage()
 	parser.Write("</b><hr>");
 	parser.Write("<form action=\"download://\">");
 	parser.Write("<input name=\"path\" type=\"text\" width=\"75%\" value=\"");
-	parser.Write(getcwd(NULL, 0));
-#ifdef _WIN32
-	parser.Write("\\");
-#endif
+
+	char* currentDirectory = getcwd(NULL, 0);
+	//Non-root folders has no \ at the end - let's add it!
+	const size_t currentDirStrLen = strlen(currentDirectory);
+	if (currentDirectory[currentDirStrLen-1] != '\\')
+	{
+		currentDirectory[currentDirStrLen] = '\\';
+	}
+	parser.Write(currentDirectory);
+	free(currentDirectory);
+
 	parser.Write(filename);
 	parser.Write("\"/><br>");
 	parser.Write("<br>");


### PR DESCRIPTION
While downloading to the root of any disk path is ok:
<img width="640" height="480" alt="MS-DOS Web-2026-03-23-18-09-04" src="https://github.com/user-attachments/assets/fc98de6d-9596-4785-97ce-9be75147a9b8" />

But while CWD is not the root, the path will be bad - it's missing a delimiter between the folder and the file name:
<img width="640" height="480" alt="MS-DOS Web-2026-03-23-18-11-14" src="https://github.com/user-attachments/assets/bee57e55-b26f-48a4-a4c3-9f92539d1b51" />

Unfortunately, the getcwd function doesn't add it, so we need to do it manually.
This solution seems to be working - adds a delimiter only when it's missing:
<img width="640" height="480" alt="MS-DOS Web-2026-03-23-18-12-27" src="https://github.com/user-attachments/assets/42c81738-b7f3-4c72-95bb-1a77efcc6947" />
